### PR TITLE
Add Network Operations to Standard Library

### DIFF
--- a/src/heather.pas
+++ b/src/heather.pas
@@ -72,6 +72,10 @@ begin
   Sender.AddMethod(FLibrary, @THeatherStdLib.GetCwd, 'function GetCwd: string;');
   Sender.AddMethod(FLibrary, @THeatherStdLib.SetCwd, 'function SetCwd(const Path: string): Boolean;');
   Sender.AddMethod(FLibrary, @THeatherStdLib.Terminate, 'procedure Terminate(ExitCode: Integer);');
+  
+  // Network Operations
+  Sender.AddMethod(FLibrary, @THeatherStdLib.DownloadFile, 'function DownloadFile(const URL, Dest: string): Boolean;');
+  Sender.AddMethod(FLibrary, @THeatherStdLib.HttpGet, 'function HttpGet(const URL: string): string;');
 end;
 
 { Loads the given script from file, compiles it, and executes it.

--- a/src/uHeatherLib.pas
+++ b/src/uHeatherLib.pas
@@ -5,7 +5,7 @@ unit uHeatherLib;
 interface
 
 uses
-  Classes, SysUtils, Process{$IFDEF MSWINDOWS}, Windows{$ENDIF};
+  Classes, SysUtils, Process, fphttpclient{$IFDEF MSWINDOWS}, Windows{$ENDIF};
 
 type
   { THeatherStdLib contains all our baked-in Python-parity functions }
@@ -37,6 +37,10 @@ type
     function GetCwd: string;
     function SetCwd(const Path: string): Boolean;
     procedure Terminate(ExitCode: Integer);
+    
+    // Network Operations
+    function DownloadFile(const URL, Dest: string): Boolean;
+    function HttpGet(const URL: string): string;
   end;
 
 implementation
@@ -331,6 +335,58 @@ end;
 procedure THeatherStdLib.Terminate(ExitCode: Integer);
 begin
   Halt(ExitCode);
+end;
+
+{ Network Operations }
+
+{ Downloads a file from a URL over HTTP/HTTPS to the specified destination.
+  @param URL The URL to download from.
+  @param Dest The local path where the file should be saved.
+  @return True if successful, False otherwise. }
+function THeatherStdLib.DownloadFile(const URL, Dest: string): Boolean;
+var
+  Client: TFPHTTPClient;
+begin
+  Result := False;
+  Client := TFPHTTPClient.Create(nil);
+  try
+    try
+      // Ensure the destination directory exists
+      if not ForceDirectories(ExtractFileDir(Dest)) then Exit;
+      
+      // Download the file
+      Client.Get(URL, Dest);
+      Result := True;
+    except
+      { Suppress exceptions to return False on failure }
+    end;
+  finally
+    Client.Free;
+  end;
+end;
+
+{ Performs a GET request and returns the response body as a string.
+  @param URL The URL to request.
+  @return The response body as a string, or empty string on failure. }
+function THeatherStdLib.HttpGet(const URL: string): string;
+var
+  Client: TFPHTTPClient;
+  ResponseStream: TStringStream;
+begin
+  Result := '';
+  Client := TFPHTTPClient.Create(nil);
+  ResponseStream := TStringStream.Create('');
+  try
+    try
+      Client.Get(URL, ResponseStream);
+      Result := ResponseStream.DataString;
+    except
+      { Suppress exceptions to return empty string on failure }
+    end;
+  finally
+    ResponseStream.Free;
+    Client.Free;
+  end;
 end;
 
 end.

--- a/test_network.pas
+++ b/test_network.pas
@@ -1,0 +1,30 @@
+program test_network;
+
+{ Test script demonstrating the new network operations in HEATHER.
+  This script tests DownloadFile and HttpGet functions. }
+
+begin
+  WriteLn('=== HEATHER Network Operations Test ===');
+  WriteLn('');
+  
+  // Test HttpGet: Fetch a simple webpage
+  WriteLn('Testing HttpGet...');
+  WriteLn('Fetching example.com...');
+  WriteLn('');
+  
+  // Note: HttpGet returns the response body as a string
+  WriteLn('HttpGet result length: ', Length(HttpGet('https://example.com')));
+  WriteLn('');
+  
+  // Test DownloadFile: Download a small file
+  WriteLn('Testing DownloadFile...');
+  WriteLn('Downloading a test file...');
+  
+  if DownloadFile('https://example.com', 'downloaded_example.html') then
+    WriteLn('Download successful! File saved to: downloaded_example.html')
+  else
+    WriteLn('Download failed.');
+  
+  WriteLn('');
+  WriteLn('=== Test Complete ===');
+end.


### PR DESCRIPTION
## Summary

This PR adds network operations to HEATHER's standard library, implementing the features requested in Issue #1.

## Changes

### New Functions Added
- `DownloadFile(const URL, Dest: string): Boolean` - Downloads a file over HTTP/HTTPS to the specified destination
- `HttpGet(const URL: string): string` - Performs a GET request and returns the response body as a string

### Implementation Details
- Added `fphttpclient` unit to `uHeatherLib.pas` for native HTTP support
- Both functions use `TFPHTTPClient` from Free Pascal's `fphttpclient` unit
- Functions are registered in `heather.pas` `OnCompile` method for script access
- Added `test_network.pas` demonstrating usage of new functions

### Acceptance Criteria Met
✅ `DownloadFile` function implemented
✅ `HttpGet` function implemented
✅ Uses native Free Pascal units (`fphttpclient`)
✅ Both functions registered in `THeatherEngine.OnCompile`
✅ Test script added demonstrating usage

## Testing

The test script `test_network.pas` can be run with:
```bash
heather test_network.pas
```

It demonstrates:
- Using `HttpGet` to fetch webpage content
- Using `DownloadFile` to download a file

Resolves #1